### PR TITLE
change blastn to object data node

### DIFF
--- a/gdcdictionary/schemas/virus_genome_variation.yaml
+++ b/gdcdictionary/schemas/virus_genome_variation.yaml
@@ -39,6 +39,12 @@ links:
         target_type: virus_sequence_run_taxonomy
         multiplicity: many_to_many
         required: false
+      - name: virus_sequences
+        backref: virus_sequence_blastns
+        label: data_from
+        target_type: virus_sequence
+        multiplicity: many_to_many
+        required: false
 
 
 required:
@@ -89,3 +95,6 @@ properties:
 
   core_metadata_collections:
     $ref: "_definitions.yaml#/to_one"
+
+  virus_sequences:
+    $ref: "_definitions.yaml#/to_many"

--- a/gdcdictionary/schemas/virus_genome_variation.yaml
+++ b/gdcdictionary/schemas/virus_genome_variation.yaml
@@ -40,7 +40,7 @@ links:
         multiplicity: many_to_many
         required: false
       - name: virus_sequences
-        backref: virus_sequence_blastns
+        backref: virus_genome_variation
         label: data_from
         target_type: virus_sequence
         multiplicity: many_to_many

--- a/gdcdictionary/schemas/virus_genome_variation.yaml
+++ b/gdcdictionary/schemas/virus_genome_variation.yaml
@@ -4,7 +4,7 @@ id: "virus_genome_variation"
 title: Virus Genome Variation
 type: object
 namespace: https://chicagoland.pandemicresponsecommons.org
-category: data_file
+category: genomic_data_file
 program: '*'
 project: '*'
 description: >
@@ -92,9 +92,13 @@ properties:
       - Low Pass WGS
       - Validation
 
-
   core_metadata_collections:
     $ref: "_definitions.yaml#/to_one"
 
   virus_sequences:
     $ref: "_definitions.yaml#/to_many"
+
+  accession_number:
+    description: >
+      SRR accession.
+    type: string

--- a/gdcdictionary/schemas/virus_sequence_blastn.yaml
+++ b/gdcdictionary/schemas/virus_sequence_blastn.yaml
@@ -4,13 +4,13 @@ id: "virus_sequence_blastn"
 title: Virus Sequence Blastn
 type: object
 namespace: https://chicagoland.pandemicresponsecommons.org
-category: analysis
+category: genomic_data_file
 program: '*'
 project: '*'
 description: >
   Provides result details for blast hit for contigs against the nucleotide blast database using the megablast algorithm.
 additionalProperties: false
-submittable: false
+submittable: ture
 validators: null
 
 systemProperties:
@@ -19,6 +19,8 @@ systemProperties:
   - created_datetime
   - updated_datetime
   - state
+  - file_state
+  - error_type
 
 links:
   - exclusive: false
@@ -41,6 +43,10 @@ links:
 required:
   - type
   - submitter_id
+  - file_name
+  - file_size
+  - md5sum
+
 
 
 uniqueKeys:
@@ -48,13 +54,9 @@ uniqueKeys:
   - [ project_id, submitter_id ]
 
 properties:
-  $ref: "_definitions.yaml#/workflow_properties"
+  $ref: "_definitions.yaml#/data_file_properties"
   type:
     enum: [ "virus_sequence_blastn" ]
-  workflow_type:
-    term:
-      $ref: "_terms.yaml#/workflow_type"
-    enum: [ "Blast hit for contigs against the nucleotide blast database" ]
 
   core_metadata_collections:
     $ref: "_definitions.yaml#/to_one"
@@ -64,60 +66,5 @@ properties:
 
   run:
     description: >
-      SRR accession.
-    type: string
-
-  contig:
-    description: >
-      Contig ID.
-    type: string
-
-  staxid:
-    description: >
-      subject taxonomic identifier.
-    type: string
-
-  sacc:
-    description: >
-      subject accession.
-    type: string
-
-  slen:
-    description: >
-      subject length.
-    type: integer
-
-  length:
-    description: >
-      hit length.
-    type: integer
-
-  bitscore:
-    description: >
-      hit bitscore.
-    type: integer
-
-  score:
-    description: >
-      hit raw score.
-    type: integer
-
-  pident:
-    description: >
-      hit percent identity.
-    type: number
-
-  sskingdom:
-    description: >
-      subject taxonomic kingdom.
-    type: string
-
-  evalue:
-    description: >
-      hit evalue.
-    type: number
-
-  ssciname:
-    description: >
-      subject taxonomic scientific name.
+      SRR accession ID.
     type: string

--- a/gdcdictionary/schemas/virus_sequence_blastn.yaml
+++ b/gdcdictionary/schemas/virus_sequence_blastn.yaml
@@ -22,6 +22,7 @@ systemProperties:
   - file_state
   - error_type
 
+
 links:
   - exclusive: false
     required: true
@@ -45,8 +46,10 @@ required:
   - submitter_id
   - file_name
   - file_size
+  - data_format
   - md5sum
-
+  - data_category
+  - data_type
 
 
 uniqueKeys:
@@ -57,6 +60,26 @@ properties:
   $ref: "_definitions.yaml#/data_file_properties"
   type:
     enum: [ "virus_sequence_blastn" ]
+
+  data_category:
+    term:
+      $ref: "_terms.yaml#/data_category"
+    enum:
+      - Nucleotide blast
+
+  data_type:
+    term:
+      $ref: "_terms.yaml#/data_type"
+    enum:
+      - Virus Sequence Blastn
+
+  data_format:
+    term:
+      $ref: "_terms.yaml#/data_format"
+    enum:
+      - json
+      - txt
+      - tsv
 
   core_metadata_collections:
     $ref: "_definitions.yaml#/to_one"

--- a/gdcdictionary/schemas/virus_sequence_blastn.yaml
+++ b/gdcdictionary/schemas/virus_sequence_blastn.yaml
@@ -39,12 +39,6 @@ links:
         target_type: virus_sequence_contig
         multiplicity: many_to_many
         required: false
-      - name: virus_sequences
-        backref: virus_sequence_blastns
-        label: data_from
-        target_type: virus_sequence
-        multiplicity: many_to_many
-        required: false
 
 
 required:
@@ -71,7 +65,7 @@ properties:
     term:
       $ref: "_terms.yaml#/data_category"
     enum:
-      - Nucleotide blast
+      - Nucleotide Blast
 
   data_type:
     term:
@@ -93,10 +87,7 @@ properties:
   virus_sequence_contigs:
     $ref: "_definitions.yaml#/to_many"
 
-  run:
+  accession_number:
     description: >
       SRR accession ID.
     type: string
-
-  virus_sequences:
-    $ref: "_definitions.yaml#/to_many"

--- a/gdcdictionary/schemas/virus_sequence_blastn.yaml
+++ b/gdcdictionary/schemas/virus_sequence_blastn.yaml
@@ -39,6 +39,12 @@ links:
         target_type: virus_sequence_contig
         multiplicity: many_to_many
         required: false
+      - name: virus_sequences
+        backref: virus_sequence_blastns
+        label: data_from
+        target_type: virus_sequence
+        multiplicity: many_to_many
+        required: false
 
 
 required:
@@ -91,3 +97,6 @@ properties:
     description: >
       SRR accession ID.
     type: string
+
+  virus_sequences:
+    $ref: "_definitions.yaml#/to_many"

--- a/gdcdictionary/schemas/virus_sequence_blastn.yaml
+++ b/gdcdictionary/schemas/virus_sequence_blastn.yaml
@@ -10,7 +10,7 @@ project: '*'
 description: >
   Provides result details for blast hit for contigs against the nucleotide blast database using the megablast algorithm.
 additionalProperties: false
-submittable: ture
+submittable: true
 validators: null
 
 systemProperties:

--- a/gdcdictionary/schemas/virus_sequence_contig.yaml
+++ b/gdcdictionary/schemas/virus_sequence_contig.yaml
@@ -4,13 +4,13 @@ id: "virus_sequence_contig"
 title: Virus Sequence Contig
 type: object
 namespace: https://chicagoland.pandemicresponsecommons.org
-category: analysis
+category: genomic_data_file
 program: '*'
 project: '*'
 description: >
   Provides details of contigs assembled from runs using SARS-CoV-2 refseq guided assembly.
 additionalProperties: false
-submittable: false
+submittable: true
 validators: null
 
 systemProperties:
@@ -19,6 +19,8 @@ systemProperties:
   - created_datetime
   - updated_datetime
   - state
+  - file_state
+  - error_type
 
 links:
   - exclusive: false
@@ -41,6 +43,12 @@ links:
 required:
   - type
   - submitter_id
+  - file_name
+  - file_size
+  - data_format
+  - md5sum
+  - data_category
+  - data_type
 
 
 uniqueKeys:
@@ -48,13 +56,29 @@ uniqueKeys:
   - [ project_id, submitter_id ]
 
 properties:
-  $ref: "_definitions.yaml#/workflow_properties"
+  $ref: "_definitions.yaml#/data_file_properties"
   type:
     enum: [ "virus_sequence_contig" ]
-  workflow_type:
+
+  data_category:
     term:
-      $ref: "_terms.yaml#/workflow_type"
-    enum: [ "Contigs assembled from runs" ]
+      $ref: "_terms.yaml#/data_category"
+    enum:
+      - Nucleotide Contig
+
+  data_type:
+    term:
+      $ref: "_terms.yaml#/data_type"
+    enum:
+      - Virus Sequence Contig
+
+  data_format:
+    term:
+      $ref: "_terms.yaml#/data_format"
+    enum:
+      - json
+      - txt
+      - tsv
 
   virus_sequences_run_taxonomies:
     $ref: "_definitions.yaml#/to_many"
@@ -62,37 +86,7 @@ properties:
   core_metadata_collections:
     $ref: "_definitions.yaml#/to_one"
 
-  name:
-    description: >
-      Contig ID.
-    type: string
-
-  run:
+  accession_number:
     description: >
       SRR accession.
-    type: string
-
-  coverage:
-    description: >
-      Average read coverage of contig.
-    type: number
-
-  tax_id:
-    description: >
-      Most prevalent taxanomic identifier by kmer-based taxonomic analysis.
-    type: integer
-
-  hits:
-    description: >
-      Number of hits to tax_id.
-    type: integer
-
-  length:
-    description: >
-      Contig length in bases.
-    type: integer
-
-  md5:
-    description: >
-      md5 based hash of the contig sequence.
     type: string

--- a/gdcdictionary/schemas/virus_sequence_contig_taxonomy.yaml
+++ b/gdcdictionary/schemas/virus_sequence_contig_taxonomy.yaml
@@ -4,13 +4,13 @@ id: "virus_sequence_contig_taxonomy"
 title: Virus Sequence Contig Taxonomy
 type: object
 namespace: https://chicagoland.pandemicresponsecommons.org
-category: analysis
+category: genomic_data_file
 program: '*'
 project: '*'
 description: >
   Provides result details of kmer-based taxonomy analysis of contigs.
 additionalProperties: false
-submittable: false
+submittable: true
 validators: null
 
 systemProperties:
@@ -19,6 +19,8 @@ systemProperties:
   - created_datetime
   - updated_datetime
   - state
+  - file_state
+  - error_type
 
 links:
   - exclusive: false
@@ -41,6 +43,12 @@ links:
 required:
   - type
   - submitter_id
+  - file_name
+  - file_size
+  - data_format
+  - md5sum
+  - data_category
+  - data_type
 
 
 uniqueKeys:
@@ -48,65 +56,37 @@ uniqueKeys:
   - [ project_id, submitter_id ]
 
 properties:
-  $ref: "_definitions.yaml#/workflow_properties"
+  $ref: "_definitions.yaml#/data_file_properties"
   type:
     enum: [ "virus_sequence_contig_taxonomy" ]
-  workflow_type:
+
+  data_category:
     term:
-      $ref: "_terms.yaml#/workflow_type"
-    enum: [ "Kmer-based taxonomy analysis" ]
+      $ref: "_terms.yaml#/data_category"
+    enum:
+      - Kmer-based Taxonomy Analysis of Contigs
+
+  data_type:
+    term:
+      $ref: "_terms.yaml#/data_type"
+    enum:
+      - Contig Taxonomy
+
+  data_format:
+    term:
+      $ref: "_terms.yaml#/data_format"
+    enum:
+      - json
+      - txt
+      - tsv
 
   virus_sequence_contigs:
     $ref: "_definitions.yaml#/to_many"
+
   core_metadata_collections:
     $ref: "_definitions.yaml#/to_one"
 
-  acc:
+  accession_number:
     description: >
       SRR accession.
     type: string
-
-  contig:
-    description: >
-      Contig ID.
-    type: string
-
-  tax_id:
-    description: >
-      taxonomic identifier from the NCBI taxonomy database.
-    type: integer
-
-  rank:
-    description: >
-      taxonomic rank assigned to the tax_id.
-    type: string
-
-  name:
-    description: >
-      scientific name associated with the tax_id.
-    type: string
-
-  total_count:
-    description: >
-      total number of kmers found in the run that are associated with the tax_id or any child tax_ids.
-    type: integer
-
-  self_count:
-    description: >
-      total number of kmers found in the run that are associated with the tax_id.
-    type: integer
-
-  ilevel:
-    description: >
-      evel index for run specific depth first enumeration of tax hierarchy.
-    type: integer
-
-  ileft:
-    description: >
-      left index for run specific depth first enumeration of tax hierarchy.
-    type: integer
-
-  iright:
-    description: >
-      right index for run specific depth first enumeration of tax hierarchy.
-    type: integer

--- a/gdcdictionary/schemas/virus_sequence_hmm_search.yaml
+++ b/gdcdictionary/schemas/virus_sequence_hmm_search.yaml
@@ -4,13 +4,13 @@ id: "virus_sequence_hmm_search"
 title: Virus Sequence HMM Search
 type: object
 namespace: https://chicagoland.pandemicresponsecommons.org
-category: analysis
+category: genomic_data_file
 program: '*'
 project: '*'
 description: >
   Provide result details for HMMER scab of contigs using a custom SARS-CoV-2 set of HMMS.
 additionalProperties: false
-submittable: false
+submittable: true
 validators: null
 
 systemProperties:
@@ -19,6 +19,8 @@ systemProperties:
   - created_datetime
   - updated_datetime
   - state
+  - file_state
+  - error_type
 
 links:
   - exclusive: false
@@ -41,20 +43,41 @@ links:
 required:
   - type
   - submitter_id
-
+  - file_name
+  - file_size
+  - data_format
+  - md5sum
+  - data_category
+  - data_type
 
 uniqueKeys:
   - [ id ]
   - [ project_id, submitter_id ]
 
 properties:
-  $ref: "_definitions.yaml#/workflow_properties"
+  $ref: "_definitions.yaml#/data_file_properties"
   type:
     enum: [ "virus_sequence_hmm_search" ]
-  workflow_type:
+
+  data_category:
     term:
-      $ref: "_terms.yaml#/workflow_type"
-    enum: [ "HMMER scab of contigs" ]
+      $ref: "_terms.yaml#/data_category"
+    enum:
+      - HMMER Scab of Contigs
+
+  data_type:
+    term:
+      $ref: "_terms.yaml#/data_type"
+    enum:
+      - Virus Sequence HMM Search
+
+  data_format:
+    term:
+      $ref: "_terms.yaml#/data_format"
+    enum:
+      - json
+      - txt
+      - tsv
 
   virus_sequence_peptides:
     $ref: "_definitions.yaml#/to_many"
@@ -62,102 +85,7 @@ properties:
   core_metadata_collections:
     $ref: "_definitions.yaml#/to_one"
 
-  run_accession:
+  accession_number:
     description: >
       SRR accession.
-    type: string
-
-  target_name:
-    description: >
-      The name of the target sequence or profile.
-    type: string
-
-  target_accession:
-    description: >
-      The accession of the target sequence or profile.
-    type: string
-
-  query_name:
-    description: >
-      The name of the query sequence or profile.
-    type: string
-
-  query_accession:
-    description: >
-      The accession of the query sequence or profile.
-    type: string
-
-  full_sequence_e_value:
-    description: >
-      The expectation value (statistical significance) of the target.
-    type: number
-
-  full_sequence_e_score:
-    description: >
-      The score (in bits) for this target/query comparison.
-    type: number
-
-  full_sequence_e_bias:
-    description: >
-      The biased-composition correction: the bit score difference contributed by the null2 mode.
-    type: number
-
-  best_domain_e_value:
-    description: >
-      The E-value if only the single best-scoring domain envelope were found in the sequence, and none of the others.
-    type: number
-
-  best_domain_e_score:
-    description: >
-      The bit score if only the single best-scoring domain envelope were found in the sequence, and none of the others.
-    type: number
-
-  best_domain_e_bias:
-    description: >
-      The null2 bias correction that was applied to the bit score of the single best-scoring domain.
-    type: number
-
-  exp:
-    description: >
-      The expected number of domains according, calculated as a weighted marginal sum over all possible alignments.
-    type: number
-
-  reg:
-    description: >
-      Number of discrete regions defined, as calculated by heuristics applied to posterior decodingof begin/end state positions in the alignment ensemble.
-    type: integer
-
-  clu:
-    description: >
-      Number of regions that appeared to be multidomain, and therefore were passed to stochastic traceback clustering for further resolution down to one or more envelopes.
-    type: integer
-
-  ov:
-    description: >
-      For envelopes that were defined by stochastic traceback clustering, how many of them overlap other envelopes.
-    type: integer
-
-  env:
-    description: >
-      The total number of envelopes defined, both by single envelope regions and by stochastic traceback clustering into one or more envelopes per region.
-    type: integer
-
-  dom:
-    description: >
-      Number of domains defined.
-    type: integer
-
-  rep:
-    description: >
-      Number of domains satisfying reporting thresholds.
-    type: integer
-
-  inc:
-    description: >
-      Number of domains satisfying inclusion thresholds.
-    type: integer
-
-  description_of_target:
-    description: >
-      The target's description line.
     type: string

--- a/gdcdictionary/schemas/virus_sequence_peptide.yaml
+++ b/gdcdictionary/schemas/virus_sequence_peptide.yaml
@@ -4,13 +4,13 @@ id: "virus_sequence_peptide"
 title: Virus Sequence Peptide
 type: object
 namespace: https://chicagoland.pandemicresponsecommons.org
-category: analysis
+category: genomic_data_file
 program: '*'
 project: '*'
 description: >
   Provides details on peptides annotated on contigs using VIGOR3.
 additionalProperties: false
-submittable: false
+submittable: true
 validators: null
 
 systemProperties:
@@ -19,6 +19,8 @@ systemProperties:
   - created_datetime
   - updated_datetime
   - state
+  - file_state
+  - error_type
 
 links:
   - exclusive: false
@@ -41,6 +43,12 @@ links:
 required:
   - type
   - submitter_id
+  - file_name
+  - file_size
+  - data_format
+  - md5sum
+  - data_category
+  - data_type
 
 
 uniqueKeys:
@@ -48,60 +56,37 @@ uniqueKeys:
   - [ project_id, submitter_id ]
 
 properties:
-  $ref: "_definitions.yaml#/workflow_properties"
+  $ref: "_definitions.yaml#/data_file_properties"
   type:
     enum: [ "virus_sequence_peptide" ]
-  workflow_type:
+
+  data_category:
     term:
-      $ref: "_terms.yaml#/workflow_type"
-    enum: [ "Peptides annotation on contigs using VIGOR3" ]
+      $ref: "_terms.yaml#/data_category"
+    enum:
+      - Peptides Annotation
+
+  data_type:
+    term:
+      $ref: "_terms.yaml#/data_type"
+    enum:
+      - Peptides Annotation Using VIGOR3
+
+  data_format:
+    term:
+      $ref: "_terms.yaml#/data_format"
+    enum:
+      - json
+      - txt
+      - tsv
 
   virus_sequence_contigs:
     $ref: "_definitions.yaml#/to_many"
+
   core_metadata_collections:
     $ref: "_definitions.yaml#/to_one"
 
-  name:
-    description: >
-      Peptide ID.
-    type: string
-
-  contig:
-    description: >
-      Contig ID.
-    type: string
-
-  run:
+  accession_number:
     description: >
       SRR accession.
-    type: string
-
-  location:
-    description: >
-      contig coordinates for the annotated gene.
-    type: string
-
-  gene:
-    description: >
-      gene name.
-    type: string
-
-  product:
-    description: >
-      peptide product name.
-    type: string
-
-  ref_db:
-    description: >
-      databse containing the reference sequence.
-    type: string
-
-  ref_id:
-    description: >
-      accession for the reference sequence.
-    type: string
-
-  sequence:
-    description: >
-      peptide sequencing.
     type: string

--- a/gdcdictionary/schemas/virus_sequence_run_taxonomy.yaml
+++ b/gdcdictionary/schemas/virus_sequence_run_taxonomy.yaml
@@ -4,13 +4,13 @@ id: "virus_sequence_run_taxonomy"
 title: Virus Sequence Run Taxonomy
 type: object
 namespace: https://chicagoland.pandemicresponsecommons.org
-category: analysis
+category: genomic_data_file
 program: '*'
 project: '*'
 description: >
   Provides result details of kmer-based taxonomy analysis of raw run data.
 additionalProperties: false
-submittable: false
+submittable: true
 validators: null
 
 systemProperties:
@@ -19,6 +19,8 @@ systemProperties:
   - created_datetime
   - updated_datetime
   - state
+  - file_state
+  - error_type
 
 links:
   - exclusive: false
@@ -41,20 +43,42 @@ links:
 required:
   - type
   - submitter_id
-
+  - file_name
+  - file_size
+  - data_format
+  - md5sum
+  - data_category
+  - data_type
 
 uniqueKeys:
   - [ id ]
   - [ project_id, submitter_id ]
 
 properties:
-  $ref: "_definitions.yaml#/workflow_properties"
+  $ref: "_definitions.yaml#/data_file_properties"
   type:
     enum: [ "virus_sequence_run_taxonomy" ]
-  workflow_type:
+
+
+  data_category:
     term:
-      $ref: "_terms.yaml#/workflow_type"
-    enum: [ "Kmer-based taxonomy analysis" ]
+      $ref: "_terms.yaml#/data_category"
+    enum:
+      - Kmer-based Taxonomy Analysis
+
+  data_type:
+    term:
+      $ref: "_terms.yaml#/data_type"
+    enum:
+      - Virus Sequence Run Taxonomy Analysis
+
+  data_format:
+    term:
+      $ref: "_terms.yaml#/data_format"
+    enum:
+      - json
+      - txt
+      - tsv
 
   virus_sequences:
     $ref: "_definitions.yaml#/to_many"
@@ -62,47 +86,7 @@ properties:
   core_metadata_collections:
     $ref: "_definitions.yaml#/to_one"
 
-  acc:
+  accession_number:
     description: >
       SRR accession.
     type: string
-
-  tax_id:
-    description: >
-      taxonomic identifier from the NCBI taxonomy database.
-    type: integer
-
-  rank:
-    description: >
-      taxonomic rank assigned to the tax_id.
-    type: string
-
-  name:
-    description: >
-      scientific name associated with the tax_id.
-    type: string
-
-  total_count:
-    description: >
-      total number of kmers found in the run that are associated with the tax_id or any child tax_ids.
-    type: integer
-
-  self_count:
-    description: >
-      total number of kmers found in the run that are associated with the tax_id.
-    type: integer
-
-  ilevel:
-    description: >
-      level index for run specific depth first enumeration of tax hierarchy.
-    type: integer
-
-  ileft:
-    description: >
-      left index for run specific depth first enumeration of tax hierarchy.
-    type: integer
-
-  iright:
-    description: >
-      right index for run specific depth first enumeration of tax hierarchy.
-    type: integer

--- a/gdcdictionary/schemas/virus_sra_run_archive.yaml
+++ b/gdcdictionary/schemas/virus_sra_run_archive.yaml
@@ -4,7 +4,7 @@ id: "virus_sra_run_archive"
 title: Virus SRA Run Archive
 type: object
 namespace: https://chicagoland.pandemicresponsecommons.org
-category: data_file
+category: genomic_data_file
 program: '*'
 project: '*'
 description: >


### PR DESCRIPTION
Jira Ticket: [COV-497](https://occ-data.atlassian.net/browse/COV-497)
Related proposal: https://docs.google.com/document/d/1bNkaElD7u7jej5IOaa5Gd3hx5sA4FY3f9rRUGmei7Qo/edit?usp=sharing

* ~Link all the NCBI Virus nodes to `virus_sequence`~ (don't need to do this, since we add `genomic_data_file` as category)

### Breaking Changes

* 6 metadata nodes (category data_file): `blastn`(**Virus Sequence Blastn**), `contigs`(**Virus Sequence Contig**), `hmmsearch_notc` (**Virus Sequence HMM Search**), `peptides`(**Virus Sequence Peptide**), `sra_taxonomy`(**Virus Sequence Run Taxonomy**), `taxonomy`(**Virus Sequence Contig Taxonomy**). Adding properties: Accession_number, File name, file size, md5, object_id
* 3 object data nodes (category data_file): `sra-src`(**Virus Sequence**), `run`(**Virus SRA Run Archive**), `RAO`(**Virus Sequence Read Align Object**). Adding properties: Accession_number, File name, file size, md5, object_id

