### PR TITLE
make data_format a string

### DIFF
--- a/gdcdictionary/schemas/virus_sequence.yaml
+++ b/gdcdictionary/schemas/virus_sequence.yaml
@@ -94,18 +94,7 @@ properties:
   data_format:
     term:
       $ref: "_terms.yaml#/data_format"
-    enum:
-      - fasta
-      - fastq
-      - sff
-      - slx
-      - slxfq
-      - qual
-      - pbi
-      - srf
-      - txt
-      - fna
-      - other
+    type: string
 
   data_source:
     description: >


### PR DESCRIPTION
### Improvements

Make the `data_format` to be a string rather than enums.

related thread in slack: https://cdis.slack.com/archives/G01C8RTKR88/p1603833376018900 