### PR TITLE
Fix race definitions

### DIFF
--- a/gdcdictionary/schemas/_definitions.yaml
+++ b/gdcdictionary/schemas/_definitions.yaml
@@ -288,3 +288,45 @@ race:
   - "Other"
   - "Left Blank"
   - "Middle Eastern or North African" # IDPH Vaccination dataset
+  termDef:
+  - term: Race
+    source: NCI Thesaurus
+    term_id: C17049
+    term_version: 18.11d (Release date:2018-11-26)
+  enumDef:
+  - enumeration: Asian
+    source: NCI Thesaurus
+    term_id: C41260
+    term_version: 18.11d (Release date:2018-11-26)
+  - enumeration: White
+    source: NCI Thesaurus
+    term_id: C41261
+    term_version: 18.11d (Release date:2018-11-26)
+  - enumeration: Black
+    source: NCI Thesaurus
+    term_id: C128938
+    term_version: 18.11d (Release date:2018-11-26)
+  - enumeration: Multi-racial
+    source: NCI Thesaurus
+    term_id: C104495
+    term_version: 18.11d (Release date:2018-11-26)
+  - enumeration: Native Hawaiian or Other Pacific Islander
+    source: NCI Thesaurus
+    term_id: C41219
+    term_version: 18.11d (Release date:2018-11-26)
+  - enumeration: American Indian or Alaskan Native
+    source: NCI Thesaurus
+    term_id: C41259
+    term_version: 18.11d (Release date:2018-11-26)
+  - enumeration: Unspecified
+    source: NCI Thesaurus
+    term_id: C38046
+    term_version: 18.09d (Release date:2018-09-24)
+  - enumeration: Unknown
+    source: NCI Thesaurus
+    term_id: C17998
+    term_version: 18.09d (Release date:2018-09-24)
+  - enumeration: Other
+    source: NCI Thesaurus
+    term_id: C17649
+    term_version: 18.09d (Release date:2018-09-24)

--- a/gdcdictionary/schemas/_definitions.yaml
+++ b/gdcdictionary/schemas/_definitions.yaml
@@ -272,3 +272,19 @@ ubiquitous_properties:
     $ref: "#/datetime"
   updated_datetime:
     $ref: "#/datetime"
+
+race:
+  term:
+    $ref: "_terms.yaml#/race"
+  enum:
+  - "Asian"
+  - "White"
+  - "Black"
+  - "Multi-racial"
+  - "Native Hawaiian or Other Pacific Islander"
+  - "American Indian or Alaskan Native"
+  - "Unspecified"
+  - "Unknown" # IDPH Vaccination dataset
+  - "Other"
+  - "Left Blank"
+  - "Middle Eastern or North African" # IDPH Vaccination dataset

--- a/gdcdictionary/schemas/demographic.yaml
+++ b/gdcdictionary/schemas/demographic.yaml
@@ -93,65 +93,7 @@ properties:
         term_version: 18.09d (Release date:2018-09-24)
 
   race:
-    term:
-      $ref: "_terms.yaml#/race"
-    enum:
-      - "Asian"
-      - "White"
-      - "Black"
-      - "Multi-racial"
-      - "Native Hawaiian/ Other Pacific Islander"
-      - "American Indian or Alaskan Native"
-      - "Unspecified"
-      - "Unknown"
-      - "Other"
-      - "Middle Eastern or North African" # IDPH Vaccination dataset
-    termDef:
-      - term: Race
-        source: NCI Thesaurus
-        term_id: C17049
-        term_version: 18.11d (Release date:2018-11-26)
-    enumDef:
-      - enumeration: Asian
-        source: NCI Thesaurus
-        term_id: C41260
-        term_version: 18.11d (Release date:2018-11-26)
-      - enumeration: White
-        source: NCI Thesaurus
-        term_id: C41261
-        term_version: 18.11d (Release date:2018-11-26)
-      - enumeration: Black
-        source: NCI Thesaurus
-        term_id: C128938
-        term_version: 18.11d (Release date:2018-11-26)
-      - enumeration: Multi-racial
-        source: NCI Thesaurus
-        term_id: C104495
-        term_version: 18.11d (Release date:2018-11-26)
-      - enumeration: Asian/Pacific Islander
-        source: NCI Thesaurus
-        term_id: C41219
-        term_version: 18.11d (Release date:2018-11-26)
-      - enumeration: American Indian or Alaskan Native
-        source: NCI Thesaurus
-        term_id: C41259
-        term_version: 18.11d (Release date:2018-11-26)
-      - enumeration: American Indian or Alaskan Native
-        source: NCI Thesaurus
-        term_id: C41259
-        term_version: 18.11d (Release date:2018-11-26)
-      - enumeration: Unspecified
-        source: NCI Thesaurus
-        term_id: C38046
-        term_version: 18.09d (Release date:2018-09-24)
-      - enumeration: Unknown
-        source: NCI Thesaurus
-        term_id: C17998
-        term_version: 18.09d (Release date:2018-09-24)
-      - enumeration: Other
-        source: NCI Thesaurus
-        term_id: C17649
-        term_version: 18.09d (Release date:2018-09-24)
+    $ref: "_definitions.yaml#/race"
 
   ethnicity:
     term:

--- a/gdcdictionary/schemas/summary_group_demographics.yaml
+++ b/gdcdictionary/schemas/summary_group_demographics.yaml
@@ -41,19 +41,7 @@ properties:
   $ref: "_definitions.yaml#/ubiquitous_properties"
 
   race:
-    description: >
-      An arbitrary classification of a taxonomic group that is a division of a species. It usually arises as a consequence of geographical isolation within a species and is characterized by shared heredity, physical attributes and behavior, and in the case of humans, by common history, nationality, or geographic distribution. The provided values are based on the categories defined by the U.S. Office of Management and Business and used by the U.S. Census Bureau.
-    enum:
-      - "American Indian or Alaska Native"
-      - "Asian"
-      - "Black"
-      - "Hispanic"
-      - "Left Blank"
-      - "Other"
-      - "Native Hawaiian or Other Pacific Islander"
-      - "White"
-      - "Unknown" # IDPH Vaccination dataset
-      - "Middle Eastern or North African" # IDPH Vaccination dataset
+    $ref: "_definitions.yaml#/race"
 
   gender:
     description: >


### PR DESCRIPTION
Jira Ticket: [COV-947](https://occ-data.atlassian.net/browse/COV-947)

remove mismatched race definitions from `summary_group_demographics.yaml` and `demographic.yaml` and add it to `_definitions.yaml` instead.


### Improvements
- Fix `race` definition so it's not mismatched in `summary_group_demographics` and `demographic` nodes
