### PR TITLE
Rename "virus_sequence_*" nodes to "virus_genome_*" (backwards compatible)

### DIFF
--- a/gdcdictionary/schemas/sample.yaml
+++ b/gdcdictionary/schemas/sample.yaml
@@ -166,20 +166,20 @@ properties:
       The collection date for the sample.
     type: string
 
-# Prop originated from ncbi-covid-19 project. To be removed after new ETL of NCBI/SRA datasets
+# Prop originated from ncbi-covid-19 project. TODO: To be removed after new ETL of NCBI/SRA datasets
   sample_accession:
     description: "SRA Sample accession in the form of SRS######## (ERS or DRS for INSDC partners)."
     type: string
-    
+
  # Prop originated from new ETL of NCBI/SRA datasets
   sra_accession:
     description: "SRA Sample accession in the form of SRS######## (ERS or DRS for INSDC partners)."
-    type: string  
-   
+    type: string
+
  # Prop originated from new ETL of NCBI/SRA datasets
   genbank_accession:
     description: "GenBank Sample accession."
-    type: string 
+    type: string
 
 # Prop originated from ncbi-covid-19 project
   biosamplemodel_sam:
@@ -290,12 +290,12 @@ properties:
   family:
     description: "The taxonomic level Family."
     type: string
-    
+
 # Prop originated from SRA/GenBank Project
   genus:
     description: "The taxonomic level Genus."
     type: string
-        
+
 # Prop originated from SRA/GenBank Project
   species:
     description: "The taxonomic level Species."

--- a/gdcdictionary/schemas/virus_genome_alignment.yaml
+++ b/gdcdictionary/schemas/virus_genome_alignment.yaml
@@ -1,14 +1,14 @@
 $schema: "http://json-schema.org/draft-04/schema#"
 
-id: "virus_sequence_alignment"
-title: Virus Sequence Alignment
+id: "virus_genome_alignment"
+title: Virus Genome Alignment
 type: object
 namespace: https://chicagoland.pandemicresponsecommons.org
 category: genomic_data_file
 program: '*'
 project: '*'
 description: >
-  Data file containing virus sequence alignment files.
+  Data file containing virus genome alignment files.
 additionalProperties: false
 submittable: true
 validators: null
@@ -27,15 +27,15 @@ links:
     required: true
     subgroup:
       - name: core_metadata_collections
-        backref: virus_sequence_alignments
+        backref: virus_genome_alignments
         label: data_from
         target_type: core_metadata_collection
         multiplicity: many_to_one
         required: false
-      - name: virus_sequences
-        backref: virus_sequence_alignments
+      - name: virus_genomes
+        backref: virus_genome_alignments
         label: data_from
-        target_type: virus_sequence
+        target_type: virus_genome
         multiplicity: many_to_many
         required: false
 
@@ -58,7 +58,7 @@ uniqueKeys:
 properties:
   $ref: "_definitions.yaml#/data_file_properties"
   type:
-    enum: [ "virus_sequence_alignment" ]
+    enum: [ "virus_genome_alignment" ]
   data_category:
     term:
       $ref: "_terms.yaml#/data_category"
@@ -91,7 +91,7 @@ properties:
       - muscle
       - Clustal Omega
 
-  virus_sequences:
+  virus_genomes:
     $ref: "_definitions.yaml#/to_many"
 
   core_metadata_collections:

--- a/gdcdictionary/schemas/virus_genome_alignment.yaml
+++ b/gdcdictionary/schemas/virus_genome_alignment.yaml
@@ -1,0 +1,98 @@
+$schema: "http://json-schema.org/draft-04/schema#"
+
+id: "virus_sequence_alignment"
+title: Virus Sequence Alignment
+type: object
+namespace: https://chicagoland.pandemicresponsecommons.org
+category: genomic_data_file
+program: '*'
+project: '*'
+description: >
+  Data file containing virus sequence alignment files.
+additionalProperties: false
+submittable: true
+validators: null
+
+systemProperties:
+  - id
+  - project_id
+  - created_datetime
+  - updated_datetime
+  - state
+  - file_state
+  - error_type
+
+links:
+  - exclusive: false
+    required: true
+    subgroup:
+      - name: core_metadata_collections
+        backref: virus_sequence_alignments
+        label: data_from
+        target_type: core_metadata_collection
+        multiplicity: many_to_one
+        required: false
+      - name: virus_sequences
+        backref: virus_sequence_alignments
+        label: data_from
+        target_type: virus_sequence
+        multiplicity: many_to_many
+        required: false
+
+
+required:
+  - type
+  - submitter_id
+  - file_name
+  - file_size
+  - data_format
+  - md5sum
+  - data_category
+  - data_type
+
+
+uniqueKeys:
+  - [ id ]
+  - [ project_id, submitter_id ]
+
+properties:
+  $ref: "_definitions.yaml#/data_file_properties"
+  type:
+    enum: [ "virus_sequence_alignment" ]
+  data_category:
+    term:
+      $ref: "_terms.yaml#/data_category"
+    enum:
+      - Nucleotide
+      - Protein
+  data_type:
+    term:
+      $ref: "_terms.yaml#/data_type"
+    enum:
+      - Sequence Alignment
+  data_format:
+    term:
+      $ref: "_terms.yaml#/data_format"
+    enum:
+      - fasta
+      - aln
+      - maf
+      - realign
+      - realign.md5
+      - bam
+      - cram
+
+  alignment_tool:
+    description : >
+        The alignment tool that was used to create the alignment file.
+    enum:
+      - MAFFT
+      - ClustalW
+      - muscle
+      - Clustal Omega
+
+  virus_sequences:
+    $ref: "_definitions.yaml#/to_many"
+
+  core_metadata_collections:
+    $ref: "_definitions.yaml#/to_one"

--- a/gdcdictionary/schemas/virus_genome_blastn.yaml
+++ b/gdcdictionary/schemas/virus_genome_blastn.yaml
@@ -1,0 +1,93 @@
+$schema: "http://json-schema.org/draft-04/schema#"
+
+id: "virus_sequence_blastn"
+title: Virus Sequence Blastn
+type: object
+namespace: https://chicagoland.pandemicresponsecommons.org
+category: genomic_data_file
+program: '*'
+project: '*'
+description: >
+  Provides result details for blast hit for contigs against the nucleotide blast database using the megablast algorithm.
+additionalProperties: false
+submittable: true
+validators: null
+
+systemProperties:
+  - id
+  - project_id
+  - created_datetime
+  - updated_datetime
+  - state
+  - file_state
+  - error_type
+
+
+links:
+  - exclusive: false
+    required: true
+    subgroup:
+      - name: core_metadata_collections
+        backref: virus_sequence_blastns
+        label: data_from
+        target_type: core_metadata_collection
+        multiplicity: many_to_one
+        required: false
+      - name: virus_sequence_contigs
+        backref: virus_sequence_blastns
+        label: data_from
+        target_type: virus_sequence_contig
+        multiplicity: many_to_many
+        required: false
+
+
+required:
+  - type
+  - submitter_id
+  - file_name
+  - file_size
+  - data_format
+  - md5sum
+  - data_category
+  - data_type
+
+
+uniqueKeys:
+  - [ id ]
+  - [ project_id, submitter_id ]
+
+properties:
+  $ref: "_definitions.yaml#/data_file_properties"
+  type:
+    enum: [ "virus_sequence_blastn" ]
+
+  data_category:
+    term:
+      $ref: "_terms.yaml#/data_category"
+    enum:
+      - Nucleotide Blast
+
+  data_type:
+    term:
+      $ref: "_terms.yaml#/data_type"
+    enum:
+      - Virus Sequence Blastn
+
+  data_format:
+    term:
+      $ref: "_terms.yaml#/data_format"
+    enum:
+      - json
+      - txt
+      - tsv
+
+  core_metadata_collections:
+    $ref: "_definitions.yaml#/to_one"
+
+  virus_sequence_contigs:
+    $ref: "_definitions.yaml#/to_many"
+
+  accession_number:
+    description: >
+      SRR accession ID.
+    type: string

--- a/gdcdictionary/schemas/virus_genome_blastn.yaml
+++ b/gdcdictionary/schemas/virus_genome_blastn.yaml
@@ -1,7 +1,7 @@
 $schema: "http://json-schema.org/draft-04/schema#"
 
-id: "virus_sequence_blastn"
-title: Virus Sequence Blastn
+id: "virus_genome_blastn"
+title: Virus Genome Blastn
 type: object
 namespace: https://chicagoland.pandemicresponsecommons.org
 category: genomic_data_file
@@ -28,15 +28,15 @@ links:
     required: true
     subgroup:
       - name: core_metadata_collections
-        backref: virus_sequence_blastns
+        backref: virus_genome_blastns
         label: data_from
         target_type: core_metadata_collection
         multiplicity: many_to_one
         required: false
-      - name: virus_sequence_contigs
-        backref: virus_sequence_blastns
+      - name: virus_genome_contigs
+        backref: virus_genome_blastns
         label: data_from
-        target_type: virus_sequence_contig
+        target_type: virus_genome_contig
         multiplicity: many_to_many
         required: false
 
@@ -59,7 +59,7 @@ uniqueKeys:
 properties:
   $ref: "_definitions.yaml#/data_file_properties"
   type:
-    enum: [ "virus_sequence_blastn" ]
+    enum: [ "virus_genome_blastn" ]
 
   data_category:
     term:
@@ -71,7 +71,7 @@ properties:
     term:
       $ref: "_terms.yaml#/data_type"
     enum:
-      - Virus Sequence Blastn
+      - Virus Genome Blastn
 
   data_format:
     term:
@@ -84,7 +84,7 @@ properties:
   core_metadata_collections:
     $ref: "_definitions.yaml#/to_one"
 
-  virus_sequence_contigs:
+  virus_genome_contigs:
     $ref: "_definitions.yaml#/to_many"
 
   accession_number:

--- a/gdcdictionary/schemas/virus_genome_contig.yaml
+++ b/gdcdictionary/schemas/virus_genome_contig.yaml
@@ -1,0 +1,92 @@
+$schema: "http://json-schema.org/draft-04/schema#"
+
+id: "virus_sequence_contig"
+title: Virus Sequence Contig
+type: object
+namespace: https://chicagoland.pandemicresponsecommons.org
+category: genomic_data_file
+program: '*'
+project: '*'
+description: >
+  Provides details of contigs assembled from runs using SARS-CoV-2 refseq guided assembly.
+additionalProperties: false
+submittable: true
+validators: null
+
+systemProperties:
+  - id
+  - project_id
+  - created_datetime
+  - updated_datetime
+  - state
+  - file_state
+  - error_type
+
+links:
+  - exclusive: false
+    required: true
+    subgroup:
+      - name: core_metadata_collections
+        backref: virus_sequence_contigs
+        label: data_from
+        target_type: core_metadata_collection
+        multiplicity: many_to_one
+        required: false
+      - name: virus_sequences_run_taxonomies
+        backref: virus_sequence_contigs
+        label: data_from
+        target_type: virus_sequence_run_taxonomy
+        multiplicity: many_to_many
+        required: false
+
+
+required:
+  - type
+  - submitter_id
+  - file_name
+  - file_size
+  - data_format
+  - md5sum
+  - data_category
+  - data_type
+
+
+uniqueKeys:
+  - [ id ]
+  - [ project_id, submitter_id ]
+
+properties:
+  $ref: "_definitions.yaml#/data_file_properties"
+  type:
+    enum: [ "virus_sequence_contig" ]
+
+  data_category:
+    term:
+      $ref: "_terms.yaml#/data_category"
+    enum:
+      - Nucleotide Contig
+
+  data_type:
+    term:
+      $ref: "_terms.yaml#/data_type"
+    enum:
+      - Virus Sequence Contig
+
+  data_format:
+    term:
+      $ref: "_terms.yaml#/data_format"
+    enum:
+      - json
+      - txt
+      - tsv
+
+  virus_sequences_run_taxonomies:
+    $ref: "_definitions.yaml#/to_many"
+
+  core_metadata_collections:
+    $ref: "_definitions.yaml#/to_one"
+
+  accession_number:
+    description: >
+      SRR accession.
+    type: string

--- a/gdcdictionary/schemas/virus_genome_contig.yaml
+++ b/gdcdictionary/schemas/virus_genome_contig.yaml
@@ -1,7 +1,7 @@
 $schema: "http://json-schema.org/draft-04/schema#"
 
-id: "virus_sequence_contig"
-title: Virus Sequence Contig
+id: "virus_genome_contig"
+title: Virus Genome Contig
 type: object
 namespace: https://chicagoland.pandemicresponsecommons.org
 category: genomic_data_file
@@ -27,15 +27,15 @@ links:
     required: true
     subgroup:
       - name: core_metadata_collections
-        backref: virus_sequence_contigs
+        backref: virus_genome_contigs
         label: data_from
         target_type: core_metadata_collection
         multiplicity: many_to_one
         required: false
-      - name: virus_sequences_run_taxonomies
-        backref: virus_sequence_contigs
+      - name: virus_genomes_run_taxonomies
+        backref: virus_genome_contigs
         label: data_from
-        target_type: virus_sequence_run_taxonomy
+        target_type: virus_genome_run_taxonomy
         multiplicity: many_to_many
         required: false
 
@@ -58,7 +58,7 @@ uniqueKeys:
 properties:
   $ref: "_definitions.yaml#/data_file_properties"
   type:
-    enum: [ "virus_sequence_contig" ]
+    enum: [ "virus_genome_contig" ]
 
   data_category:
     term:
@@ -70,7 +70,7 @@ properties:
     term:
       $ref: "_terms.yaml#/data_type"
     enum:
-      - Virus Sequence Contig
+      - Virus Genome Contig
 
   data_format:
     term:
@@ -80,7 +80,7 @@ properties:
       - txt
       - tsv
 
-  virus_sequences_run_taxonomies:
+  virus_genomes_run_taxonomies:
     $ref: "_definitions.yaml#/to_many"
 
   core_metadata_collections:

--- a/gdcdictionary/schemas/virus_genome_contig_taxonomy.yaml
+++ b/gdcdictionary/schemas/virus_genome_contig_taxonomy.yaml
@@ -1,7 +1,7 @@
 $schema: "http://json-schema.org/draft-04/schema#"
 
-id: "virus_sequence_contig_taxonomy"
-title: Virus Sequence Contig Taxonomy
+id: "virus_genome_contig_taxonomy"
+title: Virus Genome Contig Taxonomy
 type: object
 namespace: https://chicagoland.pandemicresponsecommons.org
 category: genomic_data_file
@@ -27,15 +27,15 @@ links:
     required: true
     subgroup:
       - name: core_metadata_collections
-        backref: virus_sequence_contig_taxonomies
+        backref: virus_genome_contig_taxonomies
         label: data_from
         target_type: core_metadata_collection
         multiplicity: many_to_one
         required: false
-      - name: virus_sequence_contigs
-        backref: virus_sequence_contig_taxonomies
+      - name: virus_genome_contigs
+        backref: virus_genome_contig_taxonomies
         label: data_from
-        target_type: virus_sequence_contig
+        target_type: virus_genome_contig
         multiplicity: many_to_many
         required: false
 
@@ -58,7 +58,7 @@ uniqueKeys:
 properties:
   $ref: "_definitions.yaml#/data_file_properties"
   type:
-    enum: [ "virus_sequence_contig_taxonomy" ]
+    enum: [ "virus_genome_contig_taxonomy" ]
 
   data_category:
     term:
@@ -80,7 +80,7 @@ properties:
       - txt
       - tsv
 
-  virus_sequence_contigs:
+  virus_genome_contigs:
     $ref: "_definitions.yaml#/to_many"
 
   core_metadata_collections:

--- a/gdcdictionary/schemas/virus_genome_contig_taxonomy.yaml
+++ b/gdcdictionary/schemas/virus_genome_contig_taxonomy.yaml
@@ -1,0 +1,92 @@
+$schema: "http://json-schema.org/draft-04/schema#"
+
+id: "virus_sequence_contig_taxonomy"
+title: Virus Sequence Contig Taxonomy
+type: object
+namespace: https://chicagoland.pandemicresponsecommons.org
+category: genomic_data_file
+program: '*'
+project: '*'
+description: >
+  Provides result details of kmer-based taxonomy analysis of contigs.
+additionalProperties: false
+submittable: true
+validators: null
+
+systemProperties:
+  - id
+  - project_id
+  - created_datetime
+  - updated_datetime
+  - state
+  - file_state
+  - error_type
+
+links:
+  - exclusive: false
+    required: true
+    subgroup:
+      - name: core_metadata_collections
+        backref: virus_sequence_contig_taxonomies
+        label: data_from
+        target_type: core_metadata_collection
+        multiplicity: many_to_one
+        required: false
+      - name: virus_sequence_contigs
+        backref: virus_sequence_contig_taxonomies
+        label: data_from
+        target_type: virus_sequence_contig
+        multiplicity: many_to_many
+        required: false
+
+
+required:
+  - type
+  - submitter_id
+  - file_name
+  - file_size
+  - data_format
+  - md5sum
+  - data_category
+  - data_type
+
+
+uniqueKeys:
+  - [ id ]
+  - [ project_id, submitter_id ]
+
+properties:
+  $ref: "_definitions.yaml#/data_file_properties"
+  type:
+    enum: [ "virus_sequence_contig_taxonomy" ]
+
+  data_category:
+    term:
+      $ref: "_terms.yaml#/data_category"
+    enum:
+      - Kmer-based Taxonomy Analysis of Contigs
+
+  data_type:
+    term:
+      $ref: "_terms.yaml#/data_type"
+    enum:
+      - Contig Taxonomy
+
+  data_format:
+    term:
+      $ref: "_terms.yaml#/data_format"
+    enum:
+      - json
+      - txt
+      - tsv
+
+  virus_sequence_contigs:
+    $ref: "_definitions.yaml#/to_many"
+
+  core_metadata_collections:
+    $ref: "_definitions.yaml#/to_one"
+
+  accession_number:
+    description: >
+      SRR accession.
+    type: string

--- a/gdcdictionary/schemas/virus_genome_hmm.yaml
+++ b/gdcdictionary/schemas/virus_genome_hmm.yaml
@@ -1,0 +1,92 @@
+$schema: "http://json-schema.org/draft-04/schema#"
+
+id: "virus_sequence_hmm"
+title: Virus Sequence HMM
+type: object
+namespace: https://chicagoland.pandemicresponsecommons.org
+category: genomic_data_file
+program: '*'
+project: '*'
+description: >
+  Data file containing virus sequence HMM files.
+additionalProperties: false
+submittable: true
+validators: null
+
+systemProperties:
+  - id
+  - project_id
+  - created_datetime
+  - updated_datetime
+  - state
+  - file_state
+  - error_type
+
+links:
+  - exclusive: false
+    required: true
+    subgroup:
+      - name: core_metadata_collections
+        backref: virus_sequence_hmms
+        label: data_from
+        target_type: core_metadata_collection
+        multiplicity: many_to_one
+        required: false
+      - name: virus_sequence_alignments
+        backref: virus_sequence_hmms
+        label: data_from
+        target_type: virus_sequence_alignment
+        multiplicity: many_to_one
+        required: false
+
+
+required:
+  - type
+  - submitter_id
+  - file_name
+  - file_size
+  - data_format
+  - md5sum
+  - data_category
+  - data_type
+
+
+uniqueKeys:
+  - [ id ]
+  - [ project_id, submitter_id ]
+
+properties:
+  $ref: "_definitions.yaml#/data_file_properties"
+  type:
+    enum: [ "virus_sequence_hmm" ]
+  data_category:
+    term:
+      $ref: "_terms.yaml#/data_category"
+    enum:
+      - Nucleotide
+      - Protein
+
+  data_type:
+    term:
+      $ref: "_terms.yaml#/data_type"
+    enum:
+      - Sequence HMM
+
+  data_format:
+    term:
+      $ref: "_terms.yaml#/data_format"
+    enum:
+      - txt
+      - hmmer
+
+  hmm_build_tool:
+    description : >
+        The tool that was used to create the HMM file.
+    enum:
+      - hmmbuild
+
+  virus_sequence_alignments:
+    $ref: "_definitions.yaml#/to_one"
+
+  core_metadata_collections:
+    $ref: "_definitions.yaml#/to_one"

--- a/gdcdictionary/schemas/virus_genome_hmm.yaml
+++ b/gdcdictionary/schemas/virus_genome_hmm.yaml
@@ -1,14 +1,14 @@
 $schema: "http://json-schema.org/draft-04/schema#"
 
-id: "virus_sequence_hmm"
-title: Virus Sequence HMM
+id: "virus_genome_hmm"
+title: Virus Genome HMM
 type: object
 namespace: https://chicagoland.pandemicresponsecommons.org
 category: genomic_data_file
 program: '*'
 project: '*'
 description: >
-  Data file containing virus sequence HMM files.
+  Data file containing virus genome HMM files.
 additionalProperties: false
 submittable: true
 validators: null
@@ -27,15 +27,15 @@ links:
     required: true
     subgroup:
       - name: core_metadata_collections
-        backref: virus_sequence_hmms
+        backref: virus_genome_hmms
         label: data_from
         target_type: core_metadata_collection
         multiplicity: many_to_one
         required: false
-      - name: virus_sequence_alignments
-        backref: virus_sequence_hmms
+      - name: virus_genome_alignments
+        backref: virus_genome_hmms
         label: data_from
-        target_type: virus_sequence_alignment
+        target_type: virus_genome_alignment
         multiplicity: many_to_one
         required: false
 
@@ -58,7 +58,7 @@ uniqueKeys:
 properties:
   $ref: "_definitions.yaml#/data_file_properties"
   type:
-    enum: [ "virus_sequence_hmm" ]
+    enum: [ "virus_genome_hmm" ]
   data_category:
     term:
       $ref: "_terms.yaml#/data_category"
@@ -85,7 +85,7 @@ properties:
     enum:
       - hmmbuild
 
-  virus_sequence_alignments:
+  virus_genome_alignments:
     $ref: "_definitions.yaml#/to_one"
 
   core_metadata_collections:

--- a/gdcdictionary/schemas/virus_genome_hmm_search.yaml
+++ b/gdcdictionary/schemas/virus_genome_hmm_search.yaml
@@ -1,0 +1,91 @@
+$schema: "http://json-schema.org/draft-04/schema#"
+
+id: "virus_sequence_hmm_search"
+title: Virus Sequence HMM Search
+type: object
+namespace: https://chicagoland.pandemicresponsecommons.org
+category: genomic_data_file
+program: '*'
+project: '*'
+description: >
+  Provide result details for HMMER scab of contigs using a custom SARS-CoV-2 set of HMMS.
+additionalProperties: false
+submittable: true
+validators: null
+
+systemProperties:
+  - id
+  - project_id
+  - created_datetime
+  - updated_datetime
+  - state
+  - file_state
+  - error_type
+
+links:
+  - exclusive: false
+    required: true
+    subgroup:
+      - name: core_metadata_collections
+        backref: virus_sequence_hmm_searches
+        label: data_from
+        target_type: core_metadata_collection
+        multiplicity: many_to_one
+        required: false
+      - name: virus_sequence_peptides
+        backref: virus_sequence_hmm_searches
+        label: data_from
+        target_type: virus_sequence_peptide
+        multiplicity: many_to_many
+        required: false
+
+
+required:
+  - type
+  - submitter_id
+  - file_name
+  - file_size
+  - data_format
+  - md5sum
+  - data_category
+  - data_type
+
+uniqueKeys:
+  - [ id ]
+  - [ project_id, submitter_id ]
+
+properties:
+  $ref: "_definitions.yaml#/data_file_properties"
+  type:
+    enum: [ "virus_sequence_hmm_search" ]
+
+  data_category:
+    term:
+      $ref: "_terms.yaml#/data_category"
+    enum:
+      - HMMER Scab of Contigs
+
+  data_type:
+    term:
+      $ref: "_terms.yaml#/data_type"
+    enum:
+      - Virus Sequence HMM Search
+
+  data_format:
+    term:
+      $ref: "_terms.yaml#/data_format"
+    enum:
+      - json
+      - txt
+      - tsv
+
+  virus_sequence_peptides:
+    $ref: "_definitions.yaml#/to_many"
+
+  core_metadata_collections:
+    $ref: "_definitions.yaml#/to_one"
+
+  accession_number:
+    description: >
+      SRR accession.
+    type: string

--- a/gdcdictionary/schemas/virus_genome_hmm_search.yaml
+++ b/gdcdictionary/schemas/virus_genome_hmm_search.yaml
@@ -1,7 +1,7 @@
 $schema: "http://json-schema.org/draft-04/schema#"
 
-id: "virus_sequence_hmm_search"
-title: Virus Sequence HMM Search
+id: "virus_genome_hmm_search"
+title: Virus Genome HMM Search
 type: object
 namespace: https://chicagoland.pandemicresponsecommons.org
 category: genomic_data_file
@@ -27,15 +27,15 @@ links:
     required: true
     subgroup:
       - name: core_metadata_collections
-        backref: virus_sequence_hmm_searches
+        backref: virus_genome_hmm_searches
         label: data_from
         target_type: core_metadata_collection
         multiplicity: many_to_one
         required: false
-      - name: virus_sequence_peptides
-        backref: virus_sequence_hmm_searches
+      - name: virus_genome_peptides
+        backref: virus_genome_hmm_searches
         label: data_from
-        target_type: virus_sequence_peptide
+        target_type: virus_genome_peptide
         multiplicity: many_to_many
         required: false
 
@@ -57,7 +57,7 @@ uniqueKeys:
 properties:
   $ref: "_definitions.yaml#/data_file_properties"
   type:
-    enum: [ "virus_sequence_hmm_search" ]
+    enum: [ "virus_genome_hmm_search" ]
 
   data_category:
     term:
@@ -69,7 +69,7 @@ properties:
     term:
       $ref: "_terms.yaml#/data_type"
     enum:
-      - Virus Sequence HMM Search
+      - Virus Genome HMM Search
 
   data_format:
     term:
@@ -79,7 +79,7 @@ properties:
       - txt
       - tsv
 
-  virus_sequence_peptides:
+  virus_genome_peptides:
     $ref: "_definitions.yaml#/to_many"
 
   core_metadata_collections:

--- a/gdcdictionary/schemas/virus_genome_peptide.yaml
+++ b/gdcdictionary/schemas/virus_genome_peptide.yaml
@@ -1,0 +1,92 @@
+$schema: "http://json-schema.org/draft-04/schema#"
+
+id: "virus_sequence_peptide"
+title: Virus Sequence Peptide
+type: object
+namespace: https://chicagoland.pandemicresponsecommons.org
+category: genomic_data_file
+program: '*'
+project: '*'
+description: >
+  Provides details on peptides annotated on contigs using VIGOR3.
+additionalProperties: false
+submittable: true
+validators: null
+
+systemProperties:
+  - id
+  - project_id
+  - created_datetime
+  - updated_datetime
+  - state
+  - file_state
+  - error_type
+
+links:
+  - exclusive: false
+    required: true
+    subgroup:
+      - name: core_metadata_collections
+        backref: virus_sequence_peptides
+        label: data_from
+        target_type: core_metadata_collection
+        multiplicity: many_to_one
+        required: false
+      - name: virus_sequence_contigs
+        backref: virus_sequence_peptides
+        label: data_from
+        target_type: virus_sequence_contig
+        multiplicity: many_to_many
+        required: false
+
+
+required:
+  - type
+  - submitter_id
+  - file_name
+  - file_size
+  - data_format
+  - md5sum
+  - data_category
+  - data_type
+
+
+uniqueKeys:
+  - [ id ]
+  - [ project_id, submitter_id ]
+
+properties:
+  $ref: "_definitions.yaml#/data_file_properties"
+  type:
+    enum: [ "virus_sequence_peptide" ]
+
+  data_category:
+    term:
+      $ref: "_terms.yaml#/data_category"
+    enum:
+      - Peptides Annotation
+
+  data_type:
+    term:
+      $ref: "_terms.yaml#/data_type"
+    enum:
+      - Peptides Annotation Using VIGOR3
+
+  data_format:
+    term:
+      $ref: "_terms.yaml#/data_format"
+    enum:
+      - json
+      - txt
+      - tsv
+
+  virus_sequence_contigs:
+    $ref: "_definitions.yaml#/to_many"
+
+  core_metadata_collections:
+    $ref: "_definitions.yaml#/to_one"
+
+  accession_number:
+    description: >
+      SRR accession.
+    type: string

--- a/gdcdictionary/schemas/virus_genome_peptide.yaml
+++ b/gdcdictionary/schemas/virus_genome_peptide.yaml
@@ -1,7 +1,7 @@
 $schema: "http://json-schema.org/draft-04/schema#"
 
-id: "virus_sequence_peptide"
-title: Virus Sequence Peptide
+id: "virus_genome_peptide"
+title: Virus Genome Peptide
 type: object
 namespace: https://chicagoland.pandemicresponsecommons.org
 category: genomic_data_file
@@ -27,15 +27,15 @@ links:
     required: true
     subgroup:
       - name: core_metadata_collections
-        backref: virus_sequence_peptides
+        backref: virus_genome_peptides
         label: data_from
         target_type: core_metadata_collection
         multiplicity: many_to_one
         required: false
-      - name: virus_sequence_contigs
-        backref: virus_sequence_peptides
+      - name: virus_genome_contigs
+        backref: virus_genome_peptides
         label: data_from
-        target_type: virus_sequence_contig
+        target_type: virus_genome_contig
         multiplicity: many_to_many
         required: false
 
@@ -58,7 +58,7 @@ uniqueKeys:
 properties:
   $ref: "_definitions.yaml#/data_file_properties"
   type:
-    enum: [ "virus_sequence_peptide" ]
+    enum: [ "virus_genome_peptide" ]
 
   data_category:
     term:
@@ -80,7 +80,7 @@ properties:
       - txt
       - tsv
 
-  virus_sequence_contigs:
+  virus_genome_contigs:
     $ref: "_definitions.yaml#/to_many"
 
   core_metadata_collections:

--- a/gdcdictionary/schemas/virus_genome_read_align_object.yaml
+++ b/gdcdictionary/schemas/virus_genome_read_align_object.yaml
@@ -1,7 +1,7 @@
 $schema: "http://json-schema.org/draft-04/schema#"
 
-id: "virus_sequence_read_align_object"
-title: Virus Sequence Read Align Object
+id: "virus_genome_read_align_object"
+title: Virus Genome Read Align Object
 type: object
 namespace: https://chicagoland.pandemicresponsecommons.org
 category: genomic_data_file
@@ -27,15 +27,15 @@ links:
     required: true
     subgroup:
       - name: core_metadata_collections
-        backref: virus_sequence_read_align_objects
+        backref: virus_genome_read_align_objects
         label: data_from
         target_type: core_metadata_collection
         multiplicity: many_to_one
         required: false
-      - name: virus_sequence_contigs
-        backref: virus_sequence_read_align_objects
+      - name: virus_genome_contigs
+        backref: virus_genome_read_align_objects
         label: data_from
-        target_type: virus_sequence_contig
+        target_type: virus_genome_contig
         multiplicity: many_to_many
         required: false
 
@@ -58,7 +58,7 @@ uniqueKeys:
 properties:
   $ref: "_definitions.yaml#/data_file_properties"
   type:
-    enum: [ "virus_sequence_read_align_object" ]
+    enum: [ "virus_genome_read_align_object" ]
 
   data_type:
     term:
@@ -82,5 +82,5 @@ properties:
   core_metadata_collections:
     $ref: "_definitions.yaml#/to_one"
 
-  virus_sequence_contigs:
+  virus_genome_contigs:
     $ref: "_definitions.yaml#/to_many"

--- a/gdcdictionary/schemas/virus_genome_read_align_object.yaml
+++ b/gdcdictionary/schemas/virus_genome_read_align_object.yaml
@@ -1,0 +1,86 @@
+$schema: "http://json-schema.org/draft-04/schema#"
+
+id: "virus_sequence_read_align_object"
+title: Virus Sequence Read Align Object
+type: object
+namespace: https://chicagoland.pandemicresponsecommons.org
+category: genomic_data_file
+program: '*'
+project: '*'
+description: >
+  SARS-CoV-2 Read Align Objects have been created to facilitate more rapid identification of NGS data of interest to the COVID-19 research community. This data type represents a compressed data format for more rapid data retrieval and faciliates data exploration via the pre-assembled contigs.
+additionalProperties: false
+submittable: true
+validators: null
+
+systemProperties:
+  - id
+  - project_id
+  - created_datetime
+  - updated_datetime
+  - state
+  - file_state
+  - error_type
+
+links:
+  - exclusive: false
+    required: true
+    subgroup:
+      - name: core_metadata_collections
+        backref: virus_sequence_read_align_objects
+        label: data_from
+        target_type: core_metadata_collection
+        multiplicity: many_to_one
+        required: false
+      - name: virus_sequence_contigs
+        backref: virus_sequence_read_align_objects
+        label: data_from
+        target_type: virus_sequence_contig
+        multiplicity: many_to_many
+        required: false
+
+
+required:
+  - type
+  - submitter_id
+  - file_name
+  - file_size
+  - data_format
+  - md5sum
+  - data_category
+  - data_type
+
+
+uniqueKeys:
+  - [ id ]
+  - [ project_id, submitter_id ]
+
+properties:
+  $ref: "_definitions.yaml#/data_file_properties"
+  type:
+    enum: [ "virus_sequence_read_align_object" ]
+
+  data_type:
+    term:
+      $ref: "_terms.yaml#/data_type"
+    enum:
+      - Read Align Object
+
+  data_category:
+    term:
+      $ref: "_terms.yaml#/data_category"
+    enum:
+      - Genomic sequence
+
+  data_format:
+    term:
+      $ref: "_terms.yaml#/data_format"
+    enum:
+      - realign
+      - md5
+
+  core_metadata_collections:
+    $ref: "_definitions.yaml#/to_one"
+
+  virus_sequence_contigs:
+    $ref: "_definitions.yaml#/to_many"

--- a/gdcdictionary/schemas/virus_genome_run_taxonomy.yaml
+++ b/gdcdictionary/schemas/virus_genome_run_taxonomy.yaml
@@ -1,0 +1,92 @@
+$schema: "http://json-schema.org/draft-04/schema#"
+
+id: "virus_sequence_run_taxonomy"
+title: Virus Sequence Run Taxonomy
+type: object
+namespace: https://chicagoland.pandemicresponsecommons.org
+category: genomic_data_file
+program: '*'
+project: '*'
+description: >
+  Provides result details of kmer-based taxonomy analysis of raw run data.
+additionalProperties: false
+submittable: true
+validators: null
+
+systemProperties:
+  - id
+  - project_id
+  - created_datetime
+  - updated_datetime
+  - state
+  - file_state
+  - error_type
+
+links:
+  - exclusive: false
+    required: true
+    subgroup:
+      - name: core_metadata_collections
+        backref: virus_sequence_run_taxonomies
+        label: data_from
+        target_type: core_metadata_collection
+        multiplicity: many_to_one
+        required: false
+      - name: virus_sequences
+        backref: virus_sequence_run_taxonomies
+        label: data_from
+        target_type: virus_sequence
+        multiplicity: many_to_many
+        required: false
+
+
+required:
+  - type
+  - submitter_id
+  - file_name
+  - file_size
+  - data_format
+  - md5sum
+  - data_category
+  - data_type
+
+uniqueKeys:
+  - [ id ]
+  - [ project_id, submitter_id ]
+
+properties:
+  $ref: "_definitions.yaml#/data_file_properties"
+  type:
+    enum: [ "virus_sequence_run_taxonomy" ]
+
+
+  data_category:
+    term:
+      $ref: "_terms.yaml#/data_category"
+    enum:
+      - Kmer-based Taxonomy Analysis
+
+  data_type:
+    term:
+      $ref: "_terms.yaml#/data_type"
+    enum:
+      - Virus Sequence Run Taxonomy Analysis
+
+  data_format:
+    term:
+      $ref: "_terms.yaml#/data_format"
+    enum:
+      - json
+      - txt
+      - tsv
+
+  virus_sequences:
+    $ref: "_definitions.yaml#/to_many"
+
+  core_metadata_collections:
+    $ref: "_definitions.yaml#/to_one"
+
+  accession_number:
+    description: >
+      SRR accession.
+    type: string

--- a/gdcdictionary/schemas/virus_genome_run_taxonomy.yaml
+++ b/gdcdictionary/schemas/virus_genome_run_taxonomy.yaml
@@ -1,7 +1,7 @@
 $schema: "http://json-schema.org/draft-04/schema#"
 
-id: "virus_sequence_run_taxonomy"
-title: Virus Sequence Run Taxonomy
+id: "virus_genome_run_taxonomy"
+title: Virus Genome Run Taxonomy
 type: object
 namespace: https://chicagoland.pandemicresponsecommons.org
 category: genomic_data_file
@@ -27,15 +27,15 @@ links:
     required: true
     subgroup:
       - name: core_metadata_collections
-        backref: virus_sequence_run_taxonomies
+        backref: virus_genome_run_taxonomies
         label: data_from
         target_type: core_metadata_collection
         multiplicity: many_to_one
         required: false
-      - name: virus_sequences
-        backref: virus_sequence_run_taxonomies
+      - name: virus_genomes
+        backref: virus_genome_run_taxonomies
         label: data_from
-        target_type: virus_sequence
+        target_type: virus_genome
         multiplicity: many_to_many
         required: false
 
@@ -57,7 +57,7 @@ uniqueKeys:
 properties:
   $ref: "_definitions.yaml#/data_file_properties"
   type:
-    enum: [ "virus_sequence_run_taxonomy" ]
+    enum: [ "virus_genome_run_taxonomy" ]
 
 
   data_category:
@@ -70,7 +70,7 @@ properties:
     term:
       $ref: "_terms.yaml#/data_type"
     enum:
-      - Virus Sequence Run Taxonomy Analysis
+      - Virus Genome Run Taxonomy Analysis
 
   data_format:
     term:
@@ -80,7 +80,7 @@ properties:
       - txt
       - tsv
 
-  virus_sequences:
+  virus_genomes:
     $ref: "_definitions.yaml#/to_many"
 
   core_metadata_collections:

--- a/gdcdictionary/schemas/virus_genome_variation.yaml
+++ b/gdcdictionary/schemas/virus_genome_variation.yaml
@@ -33,16 +33,16 @@ links:
         target_type: core_metadata_collection
         multiplicity: many_to_one
         required: false
-      - name: virus_sequences_run_taxonomies
+      - name: virus_genomes_run_taxonomies
         backref: virus_genome_variation
         label: data_from
-        target_type: virus_sequence_run_taxonomy
+        target_type: virus_genome_run_taxonomy
         multiplicity: many_to_many
         required: false
-      - name: virus_sequences
+      - name: virus_genomes
         backref: virus_genome_variation
         label: data_from
-        target_type: virus_sequence
+        target_type: virus_genome
         multiplicity: many_to_many
         required: false
 
@@ -65,7 +65,7 @@ uniqueKeys:
 properties:
   $ref: "_definitions.yaml#/data_file_properties"
 
-  virus_sequences_run_taxonomies:
+  virus_genomes_run_taxonomies:
     $ref: "_definitions.yaml#/to_many"
 
   data_category:
@@ -101,5 +101,5 @@ properties:
   core_metadata_collections:
     $ref: "_definitions.yaml#/to_one"
 
-  virus_sequences:
+  virus_genomes:
     $ref: "_definitions.yaml#/to_many"


### PR DESCRIPTION

### New Features
- Rename "virus_sequence_*" nodes to "virus_genome_*" (backwards compatible)
