### PR TITLE
Add `summary_group_demographics` `age_group` options

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-/gdcdictionary/schemas/ @svburke @xritter1 @yilinxu

--- a/gdcdictionary/schemas/summary_group_demographics.yaml
+++ b/gdcdictionary/schemas/summary_group_demographics.yaml
@@ -56,6 +56,8 @@ properties:
     description: >
       The age range that describes the group of subjects.
     enum:
+      - "less than 18" # city of chicago dataset
+      - "18 to 29" # city of chicago dataset
       - "less than 20"
       - "20 to 29"
       - "30 to 39"


### PR DESCRIPTION
Relates to https://github.com/uc-cdis/covid19-tools/pull/265

### Improvements
- Add `summary_group_demographics` `age_group` options "less than 18" and "18 to 29" that are needed for the city of chicago dataset
