### PR TITLE
changes made for Longcovid and Monkeypox data

### DIFF
--- a/gdcdictionary/examples/valid/subject.json
+++ b/gdcdictionary/examples/valid/subject.json
@@ -1,10 +1,11 @@
 {
     "type": "subject",
     "submitter_id": "BLGSP-71-06-00019",
-	  "hiv_status": true,
-  	"cohort_id": 31,
+    "hiv_status": true,
+    "cohort_id": 31,
     "study_center": "Chicago",
     "studies": {
         "id": "daa208a7-f57a-562c-a04a-7a7c77542c98"
-    }
+    },
+    "unique_de-id_identifier": "35632674"
 }

--- a/gdcdictionary/schemas/observation.yaml
+++ b/gdcdictionary/schemas/observation.yaml
@@ -243,7 +243,7 @@ properties:
       Check "Unknown" if symptomatic but onset date is unknown.
     enum:
       - "Unknown"
-      
+
   symp_res_dt:
     description: >
       If symptomatic, date of symptom resolution (MM/DD/YYYY)
@@ -773,3 +773,19 @@ properties:
 
   subjects:
     $ref: "_definitions.yaml#/to_one"
+
+# Prop originated for Longcovid and Monkeypox data
+
+  observations_icd10:
+    description: >
+      zero, one or more ICD-10 codes for encounter, separated by commas
+    type: array
+      items:
+        type: string
+
+  observations_cpt:
+      description: >
+        zero, one or more CPT codes for encounter, separated by commas
+      type: array
+        items:
+          type: string

--- a/gdcdictionary/schemas/observation.yaml
+++ b/gdcdictionary/schemas/observation.yaml
@@ -780,12 +780,12 @@ properties:
     description: >
       zero, one or more ICD-10 codes for encounter
     type: array
-      items:
+    items:
         type: string
 
   observations_cpt:
       description: >
         zero, one or more CPT codes for encounter
       type: array
-        items:
+      items:
           type: string

--- a/gdcdictionary/schemas/subject.yaml
+++ b/gdcdictionary/schemas/subject.yaml
@@ -41,6 +41,7 @@ links:
 required:
   - submitter_id
   - type
+  - unique_de-id_identifier
 
 uniqueKeys:
   - [id]
@@ -151,15 +152,22 @@ properties:
     description: >
       First three digits of the resident's zipcode.
     type: string
-    
+
  # Prop originated from SSR project
   version:
     description: >
       The data version as determined by the data submitter.
-    type: string   
+    type: string
 
 
   studies:
     $ref: "_definitions.yaml#/to_many"
   projects:
     $ref: "_definitions.yaml#/to_one_project"
+
+# Prop originated for Longcovid and Monkeypox data
+
+  unique_de-id_identifier:
+    description: >
+        "Unique and continuous identifier for subject"
+    type: string

--- a/gdcdictionary/schemas/subject.yaml
+++ b/gdcdictionary/schemas/subject.yaml
@@ -41,7 +41,6 @@ links:
 required:
   - submitter_id
   - type
-  - unique_de-id_identifier
 
 uniqueKeys:
   - [id]
@@ -169,5 +168,5 @@ properties:
 
   unique_de-id_identifier:
     description: >
-        "Unique and continuous identifier for subject"
+        "Unique and continuous identifier for subject (Required for Long Covid and MonkeyPox Data)"
     type: string

--- a/gdcdictionary/schemas/subject.yaml
+++ b/gdcdictionary/schemas/subject.yaml
@@ -166,7 +166,7 @@ properties:
 
 # Prop originated for Longcovid and Monkeypox data
 
-  unique_de-id_identifier:
+  unique_de_id_identifier:
     description: >
         "Unique and continuous identifier for subject (Required for Long Covid and MonkeyPox Data)"
     type: string


### PR DESCRIPTION
The long covid working group is working with OCC towards getting Long covid and monkeypox data into Pandemic response commons. This PR consist of DD changes for PRC to accommodate these data and to align the data dictionary to accommodate new fields for long covid and monkeypox data. The long covid working group has put together this documentation in which we have information to get patients' data to do analysis on long covid. [Document](https://docs.google.com/document/d/1zOU7g1pUgpGpH5GesOfcYDClZ3F074Fg8UsjriDdbmY/edit#heading=h.mep11nve4jer)

This specific PR is focusing on getting the modification to the existing nodes which are subject and observation

- subject node: Add unique_de-id_identifier to the subject node (required)

- observation node:
- Observation_icd10 -  ICD-10 code for encounter 
- Observation_cpt - CPT code for encounter
