### PR TITLE
Feat/encounter node

### DIFF
--- a/gdcdictionary/examples/valid/encounter.json
+++ b/gdcdictionary/examples/valid/encounter.json
@@ -1,0 +1,11 @@
+{
+    "type": "encounter",
+    "submitter_id": "encounter_1",
+    "encounter_type": "hospital",
+    "start_dt": "04/20/2023",
+    "end_dt": "05/01/2023",
+    "encounter_id" : "2345645",
+    "observations": {
+        "id": "obs-01"
+    }
+}

--- a/gdcdictionary/schemas/encounter.yaml
+++ b/gdcdictionary/schemas/encounter.yaml
@@ -1,0 +1,71 @@
+$schema: "http://json-schema.org/draft-04/schema#"
+
+id: "encounter"
+title: Encounter
+type: object
+namespace: https://chicagoland.pandemicresponsecommons.org
+category: clinical
+program: '*'
+project: '*'
+description: >
+  Data for each enocunter for a patient
+additionalProperties: false
+submittable: true
+validators: null
+
+systemProperties:
+  - id
+  - project_id
+  - state
+  - created_datetime
+  - updated_datetime
+
+links:
+    - name: observations
+      backref: samples
+      label: related_to
+      target_type: observation
+      multiplicity: many_to_one
+      required: false
+
+required:
+  - submitter_id
+  - type
+  - encoutner_type
+  - start_dt
+  - end_dt
+
+uniqueKeys:
+  - [id]
+  - [project_id, submitter_id]
+
+properties:
+  $ref: "_definitions.yaml#/ubiquitous_properties"
+
+# Prop originated for Longcovid and Monkeypox data
+
+  encoutner_type:
+    description: "Type of Encounter which patient have had"
+    enum:
+      - hospital
+      - ambulatory
+      - office
+      - telemedicine
+      - emergency
+
+  start_dt:
+    description: >
+      Start Date of the encounter.
+    type: string
+
+  end_dt:
+    description: >
+      End Date of the encounter.
+    type: string
+
+  encounter_id:
+    type:
+      - string
+      - "null"
+    description: >
+      unique string to identify the encounter, but it is not required if the observation node  has an observation_dt

--- a/gdcdictionary/schemas/encounter.yaml
+++ b/gdcdictionary/schemas/encounter.yaml
@@ -34,6 +34,7 @@ required:
   - encoutner_type
   - start_dt
   - end_dt
+  - encounter_id
 
 uniqueKeys:
   - [id]

--- a/gdcdictionary/schemas/sample.yaml
+++ b/gdcdictionary/schemas/sample.yaml
@@ -170,16 +170,16 @@ properties:
   sample_accession:
     description: "SRA Sample accession in the form of SRS######## (ERS or DRS for INSDC partners)."
     type: string
-    
+
  # Prop originated from new ETL of NCBI/SRA datasets
   sra_accession:
     description: "SRA Sample accession in the form of SRS######## (ERS or DRS for INSDC partners)."
-    type: string  
-   
+    type: string
+
  # Prop originated from new ETL of NCBI/SRA datasets
   genbank_accession:
     description: "GenBank Sample accession."
-    type: string 
+    type: string
 
 # Prop originated from ncbi-covid-19 project
   biosamplemodel_sam:
@@ -290,12 +290,12 @@ properties:
   family:
     description: "The taxonomic level Family."
     type: string
-    
+
 # Prop originated from SRA/GenBank Project
   genus:
     description: "The taxonomic level Genus."
     type: string
-        
+
 # Prop originated from SRA/GenBank Project
   species:
     description: "The taxonomic level Species."
@@ -316,3 +316,5 @@ properties:
     $ref: "_definitions.yaml#/datetime"
   updated_datetime:
     $ref: "_definitions.yaml#/datetime"
+  encounter:
+    $ref: "_definitions.yaml#/to_many"


### PR DESCRIPTION
The long covid working group is working with OCC towards getting Long Covid and monkeypox data into Pandemic response commons. This PR consists of DD changes for PRC to accommodate these data and to align the data dictionary to accommodate new fields for long covid and monkeypox data. The long covid working group has put together this documentation in which we have information to get patients' data to do analysis on long covid. [Document](https://docs.google.com/document/d/1zOU7g1pUgpGpH5GesOfcYDClZ3F074Fg8UsjriDdbmY/edit#heading=h.mep11nve4jer)

This specific PR is focusing on introducing a new node named "encounter", this node will be the child node of "observation". This node will have the following fields

- **encounter_type** - This field denotes the type of encounter. An encounter occurs within the hospital. The values are 1. hospital, 2. ambulatory, 3. office, 4. telemedicine, 5. emergency 
- **start_dt** - start date of encounter
- **end_dt** - end date of encounter
- **encounter_id** - distinct id associated with encounter given by the medical organization